### PR TITLE
feat: added auto sign column config. fix: was not working before

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,21 @@ local focus = require('focus')
 focus.height = 40
 
 ```
-**Set Focus Auto-Cursorline**
+
+**Set Focus Auto Cursorline**
 ```lua
 local focus = require('focus')
 -- Default: true
-focus.cursorline = true
+focus.cursorline = false
 ```
+
+**Set Focus Auto Sign Column**
+```lua
+local focus = require('focus')
+-- Default: true
+focus.signcolumn = false
+```
+
 **Set Focus Window Highlighting**
 ```lua
 local focus = require('focus')

--- a/lua/modules/autocmd.lua
+++ b/lua/modules/autocmd.lua
@@ -16,9 +16,15 @@ end
 
 function autocmd.setup(config)
   local autocmds = {
-    -- { 'BufWinEnter', '*', 'lua require \'modules.resizer\'.split_resizer('..config.width..','..config.height..')'},
-    { 'BufWinEnter', '*', 'setlocal signcolumn=no'},
+    --[[ { 'WinEnter', '*', 'setlocal signcolumn=yes'},
+    { 'WinLeave', '*', 'setlocal signcolumn=no'}, ]]
   }
+
+  if config.signcolumn ~= false then
+    -- Explicitly check against false, as it not being present should default to it being on
+    table.insert(autocmds, { 'WinEnter', '*', 'setlocal signcolumn=yes'})
+    table.insert(autocmds, { 'WinLeave', '*', 'setlocal signcolumn=no'})
+  end
 
   if config.cursorline ~= false then
     -- Explicitly check against false, as it not being present should default to it being on

--- a/lua/modules/config.lua
+++ b/lua/modules/config.lua
@@ -7,6 +7,7 @@ local defaults = {
     width = DEFAULT_WIDTH,
     height = DEFAULT_HEIGHT,
     cursorline = true,
+    signcolumn = true,
     winhighlight = false,
 }
 


### PR DESCRIPTION
this adds a focus.signcolumn config wich allows us to turn on and off
cursor line toggling when entering exiting a split