### PR TITLE
Resize windows based on golden ratio and add support to split nicely

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,32 @@ use 'beauwilliams/focus.nvim'
 | `:DisableFocus` |  Disable the plugin per session. Splits will be normalised back to defaults and then spaced evenly. |
 | `:EnableFocus` |  Enable the plugin per session. Splits will be resized back to your configs or defaults if not set. |
 | `:ToggleFocus` |  Toggle focus on and off again. |
+| `:FocusSplitNicely` | Split a window based on the golden ratio rule |
+
+## Splitting Nicely
+
+Focus allows you to split windows to tiled windows nicely.
+
+```
++----------------+------------+
+|                |    S1      |
+|                |            |
+|                +------------+
+|                |            |
+|   MAIN PANE    |    S2      |
+|                |            |
+|                |            |
+|                |            |
++----------------+------------+
+```
+
+To get this view you would press the key combination 2 times.
+
+**Split nicely with `<C-L>`**
+
+```lua
+vim.api.nvim_set_keymap('n', '<c-l>', ':FocusSplitNicely<CR>', { silent = true })
+```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 🔋 Batteries Included. No configuration neccessary
 
-👌 Maximises Current Split/Window Automatically When Cursor Moves
+👌 Maximises Current Split/Window Automatically When Cursor Moves Based On Golden Ratio
 
-⚙️  Set Focus Split/Window Width, Height, Auto-Cursorline/SignColumn & Active/Inactive Win-Highlight + Disable
+⚙️  Set Focus Auto-Cursorline/SignColumn & Active/Inactive Win-Highlight + Disable
 
 🙌 Compatible with NvimTree, NerdTree, CHADTree, Telescope, FZF & QuickFix (QF default to 10, rest won't resize)
 
@@ -59,16 +59,16 @@ focus.enable = false
 **Set Focus Width**
 ```lua
 local focus = require('focus')
--- Width for the focused window, other windows resized accordingly
--- Default: 120
+-- Force width for the focused window
+-- Default: Calculated based on golden ratio
 focus.width = 120
 ```
 
 **Set Focus Height**
 ```lua
 local focus = require('focus')
--- Height for the focused window
--- Default: 0
+-- Force height for the focused window
+-- Default: Calculated based on golden ratio
 focus.height = 40
 ```
 

--- a/lua/focus.lua
+++ b/lua/focus.lua
@@ -25,6 +25,10 @@ M.init = function()
     end
 end
 
+function M.split_nicely()
+    require('modules.split').split_nicely()
+end
+
 setmetatable(M,
     {
         __newindex = config.set,

--- a/lua/modules/config.lua
+++ b/lua/modules/config.lua
@@ -1,6 +1,4 @@
 local globals = vim.g
-local DEFAULT_WIDTH = 120
-local DEFAULT_HEIGHT = 0
 local DEFAULT_TREE_WIDTH = globals.nvim_tree_width or 30
 
 
@@ -8,8 +6,8 @@ local DEFAULT_TREE_WIDTH = globals.nvim_tree_width or 30
 local defaults = {
     enable = true,
     height_compatible = false,
-    width = DEFAULT_WIDTH,
-    height = DEFAULT_HEIGHT,
+    width = 0,
+    height = 0,
     treewidth = DEFAULT_TREE_WIDTH;
     cursorline = true,
     signcolumn = true,
@@ -18,11 +16,11 @@ local defaults = {
 
 local function verify()
     if type(defaults.width) ~= 'number' then
-        defaults.width = DEFAULT_WIDTH
+        defaults.width = 0
     end
 
     if type(defaults.height) ~= 'number' then
-        defaults.height = DEFAULT_HEIGHT
+        defaults.height = 0
     end
     if type(defaults.treewidth) ~= 'number' then
         defaults.treewidth = DEFAULT_TREE_WIDTH

--- a/lua/modules/resizer.lua
+++ b/lua/modules/resizer.lua
@@ -1,6 +1,27 @@
 local vim = vim --> Use locals
 
 local M = {}
+
+local golden_ratio = 1.618
+
+local golden_ratio_width = function()
+    local maxwidth = vim.o.columns
+    return math.floor(maxwidth / golden_ratio)
+end
+
+local golden_ratio_minwidth = function()
+    return math.floor(golden_ratio_width() / (3 * golden_ratio))
+end
+
+local golden_ratio_height = function()
+    local maxheight = vim.o.lines
+    return math.floor(maxheight / golden_ratio)
+end
+
+local golden_ratio_minheight = function()
+    return math.floor(golden_ratio_height() / (3 * golden_ratio))
+end
+
 function M.split_resizer(config) --> Only resize normal buffers, set qf to 10 always
     local ft = vim.bo.ft
     -- ft = '' is for plugins with preview windows like like snap
@@ -9,7 +30,19 @@ function M.split_resizer(config) --> Only resize normal buffers, set qf to 10 al
     elseif ft == 'qf' then
         vim.o.winheight = 10
     else
-        vim.o.winwidth = config.width --> lua print(vim.o.winwidth)
+        if config.width > 0 then
+            vim.o.winwidth = config.force_width
+        else
+            vim.o.winwidth = golden_ratio_width()
+            vim.o.winminwidth = golden_ratio_minwidth()
+        end
+
+        if config.height > 0 then
+            vim.o.winheight = config.force_height
+        else
+            vim.o.winheight = golden_ratio_height()
+            vim.o.winminheight = golden_ratio_minheight()
+        end
     end
     if ft == '' or 'toggleterm' then -- if we dont do something about the '' case, wilder.nvim resizes when searching with /
     elseif config.height ~= 0 then vim.o.winheight = config.height --> Opt in to set height value, otherwise auto-size it

--- a/lua/modules/split.lua
+++ b/lua/modules/split.lua
@@ -1,0 +1,42 @@
+local vim = vim --> Use locals
+
+local M = {}
+
+local golden_ratio = 1.618
+
+local golden_ratio_split_cmd = function(winnr)
+    local maxwidth = vim.o.columns
+    local winwidth = vim.fn.winwidth(winnr)
+    local textwidth = vim.bo.textwidth
+
+    if textwidth > 0 and winwidth > math.floor(textwidth * golden_ratio) then
+        return 'vsplit'
+    end
+
+    if winwidth > math.floor(maxwidth / golden_ratio) then
+        return 'vsplit'
+    end
+
+    return 'split'
+end
+
+local split_ENOROOM = function(err)
+    -- err: Vim(split):E36: Not enough room
+    return string.match(err, 'Vim([a-z]split):E36:.*')
+end
+
+function M.split_nicely()
+    local winnr = vim.api.nvim_get_current_win()
+    local split_cmd = golden_ratio_split_cmd(winnr)
+
+    local status, e = xpcall(vim.api.nvim_command, split_ENOROOM, split_cmd)
+    if e then
+        if split_cmd == 'split' then
+            vim.o.minwinheight = vim.o.minwinheight / 2
+        else
+            vim.o.minwinwidth = vim.o.minwinwidth / 2
+        end
+    end
+end
+
+return M

--- a/plugin/focus.vim
+++ b/plugin/focus.vim
@@ -11,6 +11,7 @@ set cpo&vim
 command! -nargs=0 DisableFocus call DisableFocus()
 command! -nargs=0 EnableFocus call EnableFocus()
 command! -nargs=0 ToggleFocus call ToggleFocus()
+command! -nargs=0 FocusSplitNicely lua require('focus').split_nicely()
 
 function! DisableFocus() abort
     if g:enabled_focus == 0


### PR DESCRIPTION
This PR changes the resizing code to use the golden ration to calculate the best split.

The new big feature it adds is to split nicely. It decides if it should do a horizontal or vertical split based on the terminal size and the text width set.

```lua
vim.api.nvim_set_keymap('n', '<c-l>', ':FocusSplitNicely<CR>', { silent = true })
```