### PR TITLE
Track split creation prior to issuing enew cmd

### DIFF
--- a/lua/focus/modules/split.lua
+++ b/lua/focus/modules/split.lua
@@ -54,7 +54,9 @@ function M.split_command(direction, fileName, tmux)
 	local winnr = vim.api.nvim_get_current_win()
 	cmd('wincmd ' .. direction)
 
+	local created = false
 	if winnr == vim.api.nvim_get_current_win() then
+		created = true
 		if tmux == true then
 			vim.fn.system('tmux select-pane -' .. vim.fn.tr(direction, 'hjkl', 'lLDUR'))
 		elseif direction == 'h' or direction == 'l' then
@@ -66,7 +68,7 @@ function M.split_command(direction, fileName, tmux)
 	end
 	if fileName ~= '' then
 		cmd('edit ' .. fileName)
-	else
+	elseif created == true then
 		cmd('enew')
 	end
 end


### PR DESCRIPTION
Forgive me if I am misunderstanding how this plugin is supposed to work.  I have the following keymaps setup

```
:nnoremap <silent> <C-h> :FocusSplitLeft<CR>
:nnoremap <silent> <C-j> :FocusSplitDown<CR>
:nnoremap <silent> <C-k> :FocusSplitUp<CR>
:nnoremap <silent> <C-l> :FocusSplitRight<CR>
```

When I switch between splits, I expect things to be resized (which they are), but additionally the active buffer is replaced with a new unnamed one, which is not what I expected, since I was trying to edit an existing one.

If i'm understanding the code correctly here (a big if lol), the `enew` command is being used to ensure that the new split doesn't have the same contents as the one that was previously selected, however in my case it was wiping out the contents of an existing split as I have `hidden` set and `enew` doesn't fail on unsaved buffers with `hidden` set.

My solution was to track whether a new split had been created and only run `enew` if it had, which has been working for me without any issues.

Feel free to close / alter this PR if this isn't the best solution (or if sending it was inappropriate).

