### PR TITLE
Add option to preserve numbers on unfocussed window

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,14 @@ require("focus").setup({relativenumber = true})
 require("focus").setup({hybridnumber = true})
 ```
 
+**Set Preserve Absolute Numbers**
+```lua
+-- Preserve absolute numbers in the unfocussed windows
+-- Works in combination with relativenumber or hybridnumber
+-- Default: false
+require("focus").setup({absolutenumber = true})
+```
+
 **Set Focus Window Highlighting**
 ```lua
 -- Enable auto highlighting for focussed/unfocussed windows

--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -28,14 +28,14 @@ function M.setup(config)
 	local autocmds = {
 		focus_resize = {
 			--Adding WinEnter no longer breaks snap etc support.. using *defer_fn* ensures filetype that is set AFTER
-            -- NOTE: Switched to vim.schedule as its more appropriate for the task and no worry about slow processors etc
-            --buffer creation is read, instead of getting the blank filetypes, buffertypes when buffer is INITIALLY created
-            -- When a buffer is created its filetype and buffertype etc are blank, and focus reads these
-            -- By using defer, focus waits for some time, and then attempts to read the filetype and buffertype
-            -- This wait time is enough for plugins to properly set their options to the buffer such as filetype
-            -- This is an upstream vim issue because there is no way to specify filetype etc when creating a new buffer
-            -- You can only create a blank buffer, and then set the variables after it was created
-            -- Which means focus will initially read it as blank buffer and resize. This is an issue for many other plugins that read ft too.
+			-- NOTE: Switched to vim.schedule as its more appropriate for the task and no worry about slow processors etc
+			--buffer creation is read, instead of getting the blank filetypes, buffertypes when buffer is INITIALLY created
+			-- When a buffer is created its filetype and buffertype etc are blank, and focus reads these
+			-- By using defer, focus waits for some time, and then attempts to read the filetype and buffertype
+			-- This wait time is enough for plugins to properly set their options to the buffer such as filetype
+			-- This is an upstream vim issue because there is no way to specify filetype etc when creating a new buffer
+			-- You can only create a blank buffer, and then set the variables after it was created
+			-- Which means focus will initially read it as blank buffer and resize. This is an issue for many other plugins that read ft too.
 			{ 'WinEnter,BufEnter', '*', 'lua vim.schedule(function() require"focus".resize() end)' },
 			{ 'WinEnter,BufEnter', 'NvimTree', 'lua require"focus".resize()' },
 		},
@@ -61,16 +61,30 @@ function M.setup(config)
 		}
 	end
 	if config.relativenumber then
-		autocmds['focus_relativenumber'] = {
-			{ 'BufEnter,WinEnter', '*', 'set nonumber relativenumber' },
-			{ 'BufLeave,WinLeave', '*', 'setlocal nonumber norelativenumber' },
-		}
+		if config.absolutenumber then
+			autocmds['focus_relativenumber'] = {
+				{ 'BufEnter,WinEnter', '*', 'set nonumber relativenumber' },
+				{ 'BufLeave,WinLeave', '*', 'setlocal number norelativenumber' },
+			}
+		else
+			autocmds['focus_relativenumber'] = {
+				{ 'BufEnter,WinEnter', '*', 'set nonumber relativenumber' },
+				{ 'BufLeave,WinLeave', '*', 'setlocal nonumber norelativenumber' },
+			}
+		end
 	end
 	if config.hybridnumber then
-		autocmds['focus_hybridnumber'] = {
-			{ 'BufEnter,WinEnter', '*', 'set number relativenumber' },
-			{ 'BufLeave,WinLeave', '*', 'setlocal nonumber norelativenumber' },
-		}
+		if config.absolutenumber then
+			autocmds['focus_hybridnumber'] = {
+				{ 'BufEnter,WinEnter', '*', 'set number relativenumber' },
+				{ 'BufLeave,WinLeave', '*', 'setlocal number norelativenumber' },
+			}
+		else
+			autocmds['focus_hybridnumber'] = {
+				{ 'BufEnter,WinEnter', '*', 'set number relativenumber' },
+				{ 'BufLeave,WinLeave', '*', 'setlocal nonumber norelativenumber' },
+			}
+		end
 	end
 
 	nvim_create_augroups(autocmds)

--- a/lua/focus/modules/config.lua
+++ b/lua/focus/modules/config.lua
@@ -12,6 +12,7 @@ local defaults = {
 	number = false,
 	relativenumber = false,
 	hybridnumber = false,
+	absolutenumber = false,
 	tmux = false,
 	bufnew = false,
 	compatible_filetrees = { 'nvimtree', 'nerdtree', 'chadtree', 'fern' },


### PR DESCRIPTION
Add the `absolutenumber` option to preserver numbers on unfocussed window if `relativenumber` or `hydribenumber` is enabled.

fixes: beauwilliams/focus.nvim#58