### PR TITLE
Fix FocusSplitNicely

### DIFF
--- a/lua/focus/modules/split.lua
+++ b/lua/focus/modules/split.lua
@@ -56,7 +56,8 @@ function M.split_nicely(args, bufnew)
 	local split_cmd = golden_ratio_split_cmd(winnr)
 
 	-- this allows use to get 4 split layout
-	if #vim.api.nvim_tabpage_list_wins({ 0 }) == 4 then
+	-- if #vim.api.nvim_tabpage_list_wins({ 0 }) == 4 then
+	if #vim.api.nvim_tabpage_list_wins(0) == 4 then
 		cmd('wincmd w')
 	end
 


### PR DESCRIPTION
This maybe related to the recent-ish breaking change in neovim.
They made most api functions that take a winnr or bufnr more strict in
requiring an integer rather than accepting nil or anything else.
