### PR TITLE
Feat: Add 'forced_filetypes' as override to 'excluded_buftypes'.

### DIFF
--- a/lua/focus/modules/config.lua
+++ b/lua/focus/modules/config.lua
@@ -25,6 +25,7 @@ local defaults = {
 	compatible_filetrees = { 'nvimtree', 'nerdtree', 'chadtree', 'fern' },
 	excluded_filetypes = {},
 	excluded_buftypes = { 'nofile', 'prompt', 'popup' },
+	forced_filetypes = { 'dap-repl' },
 }
 
 local function verify()

--- a/lua/focus/modules/resizer.lua
+++ b/lua/focus/modules/resizer.lua
@@ -32,6 +32,7 @@ function M.split_resizer(config) --> Only resize normal buffers, set qf to 10 al
 	local filetrees_set = utils.to_set(utils.to_lower(config.compatible_filetrees))
 	local excluded_ft_set = utils.to_set(utils.to_lower(config.excluded_filetypes))
 	local excluded_bt_set = utils.to_set(utils.to_lower(config.excluded_buftypes))
+	local forced_ft_set = utils.to_set(utils.to_lower(config.forced_filetypes))
 	if vim.g.enabled_focus_resizing == 0 then
 		return
 	elseif ft == 'diffviewfiles' then
@@ -45,7 +46,7 @@ function M.split_resizer(config) --> Only resize normal buffers, set qf to 10 al
 	elseif filetrees_set[ft] or ft == 'nvimtree' then
 		vim.o.winminwidth = 0
 		vim.o.winwidth = config.treewidth
-	elseif excluded_bt_set[bt] or excluded_ft_set[ft] then
+	elseif (excluded_bt_set[bt] or excluded_ft_set[ft]) and not forced_ft_set[ft] then
 		vim.o.winminheight = 0
 		vim.o.winheight = 1
 		vim.o.winminwidth = 0


### PR DESCRIPTION
I had the situation where I wanted to enable resizing of a buffer (whose buffer type was correctly excluded given its wider use-case but) for a particular filetype (`dan-repl`) for which I wanted it enabled. I confess this was a quick and dirty hack but thought I'd share it here to see if it might be of interest and spark some discussion around any thoughts around a better implementation 😇 