### PR TITLE
Fix: Fixed NvimTree integration

### DIFF
--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -38,7 +38,7 @@ function M.setup(config)
 			-- You can only create a blank buffer, and then set the variables after it was created
 			-- Which means focus will initially read it as blank buffer and resize. This is an issue for many other plugins that read ft too.
 			{ 'WinEnter,BufEnter', '*', 'lua vim.schedule(function() require"focus".resize() end)' },
-			{ 'WinEnter,BufEnter', 'NvimTree', 'lua require"focus".resize()' },
+			{ 'WinEnter,BufEnter', 'NvimTree_*', 'lua require"focus".resize()' },
 		}
 	end
 


### PR DESCRIPTION
Recently NvimTree changed the buffer name from `NvimTree` to
`NvimTree_{number}`, this change fixes the detection in autocmd.lua
See https://github.com/kyazdani42/nvim-tree.lua/commit/0e7856fd8de18edaaee8fa0c2f2c9432c973aef5

Closes: #79