### PR TITLE
fire WinScrolled after delayed autoresize

### DIFF
--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -37,7 +37,7 @@ function M.setup(config)
 			-- This is an upstream vim issue because there is no way to specify filetype etc when creating a new buffer
 			-- You can only create a blank buffer, and then set the variables after it was created
 			-- Which means focus will initially read it as blank buffer and resize. This is an issue for many other plugins that read ft too.
-			{ 'WinEnter,BufEnter', '*', 'lua vim.schedule(function() require"focus".resize() end)' },
+			{ 'WinEnter,BufEnter', '*', 'lua vim.schedule(function() require"focus".resize(); vim.cmd([[doautocmd WinScrolled]]) end)' },
 			{ 'WinEnter,BufEnter', 'NvimTree_*', 'lua require"focus".resize()' },
 		}
 	end


### PR DESCRIPTION
I discovered a compatibility issue with [incline.nvim](https://github.com/b0o/incline.nvim) where the incline floating window wouldn't be moved after the focus.nvim autoresize. 

[incline.nvim is actually listening to `WinScrolled` to know when a pane was resized](https://github.com/b0o/incline.nvim/blob/fc2a494c42c465c61f92ca56a6d5a873866522c1/lua/incline/manager.lua#L74-L92), which also sounds like [a valid use of the event](https://neovim.io/doc/user/autocmd.html#WinScrolled). And because [the `resize()` call is delayed via `vim.schedule`](https://github.com/beauwilliams/focus.nvim/blob/86d036649ab8d00ac8fdca750533a541b892e4fb/lua/focus/modules/autocmd.lua#L27-L43), incline is getting the pane sizes _before_ the focus.nvim change. 

Firing `WinScrolled` after the auto-resize seems like the best solution for me, I'm happy to change it if not. 