### PR TITLE
[Feature/Fix]: - [Feat]: Allow to change the value of sign column in focused window from any buffer, bring exclude filetypes, buftypes comback - [Fix]: Prevent sign column from updating when buffer is disabled when buffer enter or out

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ Always have a nice view over your split windows
 
 ![screencast](https://i.ibb.co/0tsKww4/focusop.gif)
 
-*Note*: For reference this screencast features dimensions set to 40 rows and 120
+_Note_: For reference this screencast features dimensions set to 40 rows and 120
 columns.
 
-*See a visual demonstration of each focus feature
-[here](https://github.com/nvim-focus/focus.nvim/blob/master/DEMO.md)*.
+_See a visual demonstration of each focus feature
+[here](https://github.com/nvim-focus/focus.nvim/blob/master/DEMO.md)_.
 
 ## Features
 
-* 👌 Resizes split windows automatically based on [golden ratio](https://en.wikipedia.org/wiki/Golden_ratio)
-* ⚙️ Enables cursorline/signcolumn/numbers on focus window only
-* 🙌 Window creation or switch by direction
-* 🖥 Equalise splits or maximise focused splits, and toggle between the two
-* 🔌 Option to open tmux windows instead of creating new splits
+- 👌 Resizes split windows automatically based on [golden ratio](https://en.wikipedia.org/wiki/Golden_ratio)
+- ⚙️ Enables cursorline/signcolumn/numbers on focus window only
+- 🙌 Window creation or switch by direction
+- 🖥 Equalise splits or maximise focused splits, and toggle between the two
+- 🔌 Option to open tmux windows instead of creating new splits
 
 ## Installation
 
@@ -135,15 +135,31 @@ require("focus").setup({
             enable = false, -- Display colorcolumn in the foccused window only
             list = '+1', -- Set the comma-saperated list for the colorcolumn
         },
-        signcolumn = true, -- Display signcolumn in the focussed window only
-        winhighlight = false, -- Auto highlighting for focussed/unfocussed windows
-    }
+		signcolumn_focused_value = "yes",
+		winhighlight = false, -- Auto highlighting for focussed/unfocussed windows
+	},
+	excluded = {
+		filetypes = {
+			"NvimTree",
+			"startify",
+			"dashboard",
+			"TelescopePrompt",
+			"lazy",
+		},
+		buftypes = {
+			"nofile",
+			"prompt",
+			"popup",
+			"acwrite",
+		},
+	},
 })
 ```
 
 ### Setup options
 
 **Enable/Disable Focus**
+
 ```lua
 -- Completely disable this plugin
 -- Default: true
@@ -151,6 +167,7 @@ require("focus").setup({enable = false})
 ```
 
 **Enable/Disable Focus Commands**
+
 ```lua
 -- This not export :Focus* commands
 -- Default: true
@@ -158,14 +175,15 @@ require("focus").setup({commands = false})
 ```
 
 **Enable/Disable Focus Window Autoresizing**
+
 ```lua
 --The focussed window will no longer automatically resize. Other focus features are still available
 -- Default: true
 require("focus").setup({ autoresize = { enable = false } })
 ```
 
-
 **Set Focus Width**
+
 ```lua
 -- Force width for the focused window
 -- Default: Calculated based on golden ratio
@@ -173,6 +191,7 @@ require("focus").setup({ autoresize = { width = 120 } })
 ```
 
 **Set Focus Minimum Width**
+
 ```lua
 -- Force minimum width for the unfocused window
 -- Default: Calculated based on golden ratio
@@ -180,6 +199,7 @@ require("focus").setup({ autoresize = { minwidth = 80} })
 ```
 
 **Set Focus Height**
+
 ```lua
 -- Force height for the focused window
 -- Default: Calculated based on golden ratio
@@ -187,6 +207,7 @@ require("focus").setup({ autoresize = { height = 40 } })
 ```
 
 **Set Focus Minimum Height**
+
 ```lua
 -- Force minimum height for the unfocused window
 -- Default: 0
@@ -194,6 +215,7 @@ require("focus").setup({ autoresize = { minheight = 10} })
 ```
 
 **Set Focus Quickfix Height**
+
 ```lua
 -- Sets the height of quickfix panel, in case you pass the height to
 -- `:copen <height>`
@@ -202,6 +224,7 @@ require("focus").setup({ autoresize = { height_quickfix = 10 })
 ```
 
 **When creating a new split window, do/don't initialise it as an empty buffer**
+
 ```lua
 -- True: When a :Focus.. command creates a new split window, initialise it as a new blank buffer
 -- False: When a :Focus.. command creates a new split, retain a copy of the current window in the new window
@@ -210,6 +233,7 @@ require("focus").setup({ split = { bufnew = true } })
 ```
 
 **Set Focus Auto Numbers**
+
 ```lua
 -- Displays line numbers in the focussed window only
 -- Not displayed in unfocussed windows
@@ -218,6 +242,7 @@ require("focus").setup({ui = { number = false } })
 ```
 
 **Set Focus Auto Relative Numbers**
+
 ```lua
 -- Displays relative line numbers in the focussed window only
 -- Not displayed in unfocussed windows
@@ -227,6 +252,7 @@ require("focus").setup({ ui = { relativenumber = true } })
 ```
 
 **Set Focus Auto Hybrid Numbers**
+
 ```lua
 -- Displays hybrid line numbers in the focussed window only
 -- Not displayed in unfocussed windows
@@ -237,6 +263,7 @@ require("focus").setup({ ui = { hybridnumber = true} })
 ```
 
 **Set Presrve Absolute Numbers**
+
 ```lua
 -- Preserve absolute numbers in the unfocussed windows
 -- Works in combination with relativenumber or hybridnumber
@@ -245,6 +272,7 @@ require("focus").setup({ ui = { absolutenumber_unfocussed = true } })
 ```
 
 **When creating a new split window, use tmux split instead of neovim**
+
 ```lua
 -- True: Create tmux splits instead of neovim splits
 -- False: Create neovim split windows
@@ -253,6 +281,7 @@ require("focus").setup({ split = { tmux = true } })
 ```
 
 **Set Focus Auto Cursor Line**
+
 ```lua
 -- Displays a cursorline in the focussed window only
 -- Not displayed in unfocussed windows
@@ -261,6 +290,7 @@ require("focus").setup({ ui = { cursorline = false } })
 ```
 
 **Set Focus Auto Cursor Column**
+
 ```lua
 -- Displays a cursor column in the focussed window only
 -- See :help cursorcolumn for more options
@@ -269,6 +299,7 @@ require("focus").setup({ ui = { cursorcolumn = true } })
 ```
 
 **Set Focus Auto Color Column**
+
 ```lua
 -- Displays a color column in the focussed window only
 -- See :help colorcolumn for more options
@@ -284,6 +315,7 @@ require("focus").setup({
 ```
 
 **Set Focus Auto Sign Column**
+
 ```lua
 -- Displays a sign column in the focussed window only
 -- Gets the vim variable setcolumn when focus.setup() is run
@@ -293,6 +325,7 @@ require("focus").setup({ ui = { signcolumn = false } })
 ```
 
 **Set Focus Window Highlighting**
+
 ```lua
 -- Enable auto highlighting for focussed/unfocussed windows
 -- Default: false
@@ -347,27 +380,27 @@ vim.api.nvim_create_autocmd('FileType', {
 
 ## Vim Commands
 
-*For more information on below commands scroll down to see them each described
-in more detail*
+_For more information on below commands scroll down to see them each described
+in more detail_
 
-| _Command_                  | _Description_                                   |
-| -------------------------- | ----------------------------------------------- |
-| `:FocusDisable`            | Disable the plugin per session. Splits will be normalized back to defaults and then spaced evenly. |
-| `:FocusEnable`             | Enable the plugin per session. Splits will be resized back to your configs or defaults if not set. |
-| `:FocusToggle`             | Toggle focus on and off again.                  |
-| `:FocusSplitNicely`        | Split a window based on the golden ratio rule.  |
+| _Command_                  | _Description_                                                                                                                 |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `:FocusDisable`            | Disable the plugin per session. Splits will be normalized back to defaults and then spaced evenly.                            |
+| `:FocusEnable`             | Enable the plugin per session. Splits will be resized back to your configs or defaults if not set.                            |
+| `:FocusToggle`             | Toggle focus on and off again.                                                                                                |
+| `:FocusSplitNicely`        | Split a window based on the golden ratio rule.                                                                                |
 | `:FocusSplitCycle`         | If there are no splits, create one and move to it, else cycle focussed split. `:FocusSplitCycle reverse` for counterclockwise |
-| `:FocusDisableWindow`      | Disable resizing of the current window (winnr). |
-| `:FocusEnableWindow`       | Enable resizing of the current window (winnr).  |
-| `:FocusToggleWindow`       | Toggle focus on and off again on a per window basis. |
-| `:FocusGetDisabledWindows` | Pretty prints the list of disabled window ID's along with the current window ID. |
-| `:FocusSplitLeft`          | Move to existing or create a new split to the left of your current window + open file or custom command. |
-| `:FocusSplitDown`          | Move to existing or create a new split to the bottom of your current window + open file or custom command. |
-| `:FocusSplitUp`            | Move to existing or create a new split to the top of your current window + open file or custom command. |
-| `:FocusSplitRight`         | Move to existing or create a new split to the right of your current window + open file or custom command. |
-| `:FocusEqualise`           | Temporarily equalises the splits so they are all of similar width/height. |
-| `:FocusMaximise`           | Temporarily maximises the focussed window.      |
-| `:FocusMaxOrEqual`         | Toggles Between having the splits equalised or the focussed window maximised. |
+| `:FocusDisableWindow`      | Disable resizing of the current window (winnr).                                                                               |
+| `:FocusEnableWindow`       | Enable resizing of the current window (winnr).                                                                                |
+| `:FocusToggleWindow`       | Toggle focus on and off again on a per window basis.                                                                          |
+| `:FocusGetDisabledWindows` | Pretty prints the list of disabled window ID's along with the current window ID.                                              |
+| `:FocusSplitLeft`          | Move to existing or create a new split to the left of your current window + open file or custom command.                      |
+| `:FocusSplitDown`          | Move to existing or create a new split to the bottom of your current window + open file or custom command.                    |
+| `:FocusSplitUp`            | Move to existing or create a new split to the top of your current window + open file or custom command.                       |
+| `:FocusSplitRight`         | Move to existing or create a new split to the right of your current window + open file or custom command.                     |
+| `:FocusEqualise`           | Temporarily equalises the splits so they are all of similar width/height.                                                     |
+| `:FocusMaximise`           | Temporarily maximises the focussed window.                                                                                    |
+| `:FocusMaxOrEqual`         | Toggles Between having the splits equalised or the focussed window maximised.                                                 |
 
 ## Splitting Nicely
 
@@ -400,20 +433,19 @@ end, { desc = 'split nicely' })
 Additionally you can open a file or a run a custom command with the
 `:FocusSplitNicely` command
 
-*Opens a file in the split created by `FocusSplitNicely` command*
+_Opens a file in the split created by `FocusSplitNicely` command_
 
 `:FocusSplitNicely README.md`
 
-*Opens a terminal window in the split created by `FocusSplitNicely` command by
- using the cmd arg to run a custom command*
+_Opens a terminal window in the split created by `FocusSplitNicely` command by
+using the cmd arg to run a custom command_
 
 `:FocusSplitNicely cmd term`
 
-
 ## Split directionally
 
-Instead of worrying about multiple commands and shortcuts, *simply think about
-splits as to which direction you would like to go*.
+Instead of worrying about multiple commands and shortcuts, _simply think about
+splits as to which direction you would like to go_.
 
 Calling a focus split command i.e :FocusSplitRight will do one of two things,
 **it will attempt to move across to the window** in the specified direction.
@@ -440,29 +472,28 @@ focusmap('l')
 Additionally you can open a file or a run a custom command with the
 `:FocusSplit<direction>` command
 
-*Opens a file in a split that was either created or moved to*
+_Opens a file in a split that was either created or moved to_
 
 `:FocusSplitRight README.md`
 
-*Opening a terminal window by using the cmd arg to run a custom command in a
-split that was created or moved to*
+_Opening a terminal window by using the cmd arg to run a custom command in a
+split that was created or moved to_
 
 `:FocusSplitDown cmd term`
 
 ## FAQ
 
-* **I have a small display and I am finding splits are resized too much**
+- **I have a small display and I am finding splits are resized too much**
 
-  If for example your screen resolution is *1024x768* --> i.e on the smaller
-  side, you may notice that focus by default can maximise a window *too much*.
+  If for example your screen resolution is _1024x768_ --> i.e on the smaller
+  side, you may notice that focus by default can maximise a window _too much_.
 
   That is, the window will sort of 'crush' some of your other splits due to the
   limited screen real estate. This is not an issue with focus, but an issue with
   minimal screen real estate. In this case, you can simply reduce the
   width/height of focus.
 
-
-* **Quickfix window opens in the right split always.
+- **Quickfix window opens in the right split always.
   Is this caused by focus.lua?**
 
   No. This is a
@@ -473,7 +504,7 @@ split that was created or moved to*
   In the meantime, you can open a quickfix window occupying the the full width
   of the window with `:botright copen`
 
-* **I tried to lazy load focus with `:FocusToggle`, but I need to toggle it
+- **I tried to lazy load focus with `:FocusToggle`, but I need to toggle it
   again to get auto-resizing working**
 
   Please note if you lazy load with command `:FocusToggle`, it will load focus,
@@ -485,9 +516,9 @@ split that was created or moved to*
 
 ## Similar plugins
 
-* [anuvyklack/windows.nvim](https://github.com/anuvyklack/windows.nvim)
-* [zhaocai/GoldenView.Vim](https://github.com/zhaocai/GoldenView.Vim)
-* [Bekaboo/deadcolumn.nvim](https://github.com/Bekaboo/deadcolumn.nvim)
+- [anuvyklack/windows.nvim](https://github.com/anuvyklack/windows.nvim)
+- [zhaocai/GoldenView.Vim](https://github.com/zhaocai/GoldenView.Vim)
+- [Bekaboo/deadcolumn.nvim](https://github.com/Bekaboo/deadcolumn.nvim)
 
 ## Developers Only
 

--- a/lua/focus/init.lua
+++ b/lua/focus/init.lua
@@ -209,7 +209,6 @@ H.setup_config = function(config)
             'string',
         },
         ['ui.winhighlight'] = { config.ui.winhighlight, 'boolean' },
-        ['ui.winhighlight'] = { config.ui.winhighlight, 'boolean' },
     })
 
     vim.validate({

--- a/lua/focus/init.lua
+++ b/lua/focus/init.lua
@@ -49,9 +49,9 @@ Focus.config = {
         signcolumn_focused_value = 'auto', -- Set the value of signcolumn for the focused window only (yes, number, auto)
         winhighlight = false,              -- Auto highlighting for focussed/unfocussed windows
     },
-    exclude = {
-        filetypes = {}, -- Filetypes to exclude from Focus
-        buftypes = {},  -- Buftypes to exclude from Focus
+    excluded = {
+        filetypes = {}, -- Filetypes to excluded from Focus
+        buftypes = {},  -- Buftypes to excluded from Focus
     },
 }
 
@@ -171,7 +171,7 @@ H.setup_config = function(config)
         autoresize = { config.autoresize, 'table', true },
         split = { config.split, 'table', true },
         ui = { config.split, 'table', true },
-        exclude = { config.exclude, 'table', true },
+        excluded = { config.excluded, 'table', true },
     })
 
     vim.validate({
@@ -216,8 +216,8 @@ H.setup_config = function(config)
     })
 
     vim.validate({
-        ['exclude.filetypes'] = { config.exclude.filetypes, 'table' },
-        ['exclude.buftypes'] = { config.exclude.buftypes, 'table' },
+        ['excluded.filetypes'] = { config.excluded.filetypes, 'table' },
+        ['excluded.buftypes'] = { config.excluded.buftypes, 'table' },
     })
 
     return config

--- a/lua/focus/init.lua
+++ b/lua/focus/init.lua
@@ -19,40 +19,39 @@ local H = {}
 local Focus = {}
 
 Focus.config = {
-    enable = true, -- Enable module
-    commands = true, -- Create Focus commands
+    enable = true,            -- Enable module
+    commands = true,          -- Create Focus commands
     autoresize = {
-        enable = true, -- Enable or disable auto-resizing of splits
-        width = 0, -- Force width for the focused window
-        height = 0, -- Force height for the focused window
-        minwidth = 0, -- Force minimum width for the unfocused window
-        minheight = 0, -- Force minimum height for the unfocused window
+        enable = true,        -- Enable or disable auto-resizing of splits
+        width = 0,            -- Force width for the focused window
+        height = 0,           -- Force height for the focused window
+        minwidth = 0,         -- Force minimum width for the unfocused window
+        minheight = 0,        -- Force minimum height for the unfocused window
         height_quickfix = 10, -- Set the height of quickfix panel
     },
     split = {
         bufnew = false, -- Create blank buffer for new split windows
-        tmux = false, -- Create tmux splits instead of neovim splits
+        tmux = false,   -- Create tmux splits instead of neovim splits
     },
     ui = {
-        number = false, -- Display line numbers in the focussed window only
-        relativenumber = false, -- Display relative line numbers in the focussed window only
-        hybridnumber = false, -- Display hybrid line numbers in the focussed window only
+        number = false,                    -- Display line numbers in the focussed window only
+        relativenumber = false,            -- Display relative line numbers in the focussed window only
+        hybridnumber = false,              -- Display hybrid line numbers in the focussed window only
         absolutenumber_unfocussed = false, -- Preserve absolute numbers in the unfocussed windows
 
-        cursorline = true, -- Display a cursorline in the focussed window only
-        cursorcolumn = false, -- Display cursorcolumn in the focussed window only
+        cursorline = true,                 -- Display a cursorline in the focussed window only
+        cursorcolumn = false,              -- Display cursorcolumn in the focussed window only
         colorcolumn = {
-            enable = false, -- Display colorcolumn in the foccused window only
-            list = '+1', -- Set the comma-saperated list for the colorcolumn
+            enable = false,                -- Display colorcolumn in the foccused window only
+            list = '+1',                   -- Set the comma-saperated list for the colorcolumn
         },
-        signcolumn = true, -- Display signcolumn in the focussed window only
+        signcolumn = true,                 -- Display signcolumn in the focussed window only
         signcolumn_focused_value = 'auto', -- Set the value of signcolumn for the focused window only (yes, number, auto)
-        winhighlight = false, -- Auto highlighting for focussed/unfocussed windows
+        winhighlight = false,              -- Auto highlighting for focussed/unfocussed windows
     },
     exclude = {
         filetypes = {}, -- Filetypes to exclude from Focus
-        buftypes = {}, -- Buftypes to exclude from Focus
-        bufnames = {}, -- File names to exclude from Focus
+        buftypes = {},  -- Buftypes to exclude from Focus
     },
 }
 
@@ -88,7 +87,7 @@ Focus.setup = function(config)
             end
 
             vim.wo.winhighlight =
-                'Normal:FocusedWindow,NormalNC:UnfocusedWindow'
+            'Normal:FocusedWindow,NormalNC:UnfocusedWindow'
         end
 
         if config.autoresize then
@@ -219,7 +218,6 @@ H.setup_config = function(config)
     vim.validate({
         ['exclude.filetypes'] = { config.exclude.filetypes, 'table' },
         ['exclude.buftypes'] = { config.exclude.buftypes, 'table' },
-        ['exclude.bufnames'] = { config.exclude.bufnames, 'table' },
     })
 
     return config

--- a/lua/focus/init.lua
+++ b/lua/focus/init.lua
@@ -49,6 +49,11 @@ Focus.config = {
         signcolumn_focused_value = 'auto', -- Set the value of signcolumn for the focused window only (yes, number, auto)
         winhighlight = false, -- Auto highlighting for focussed/unfocussed windows
     },
+    exclude = {
+        filetypes = {}, -- Filetypes to exclude from Focus
+        buftypes = {}, -- Buftypes to exclude from Focus
+        bufnames = {}, -- File names to exclude from Focus
+    },
 }
 
 --- Module setup
@@ -167,6 +172,7 @@ H.setup_config = function(config)
         autoresize = { config.autoresize, 'table', true },
         split = { config.split, 'table', true },
         ui = { config.split, 'table', true },
+        exclude = { config.exclude, 'table', true },
     })
 
     vim.validate({
@@ -209,6 +215,12 @@ H.setup_config = function(config)
     vim.validate({
         ['ui.colorcolumn.enable'] = { config.ui.colorcolumn.enable, 'boolean' },
         ['ui.colorcolumn.list'] = { config.ui.colorcolumn.list, 'string' },
+    })
+
+    vim.validate({
+        ['exclude.filetypes'] = { config.exclude.filetypes, 'table' },
+        ['exclude.buftypes'] = { config.exclude.buftypes, 'table' },
+        ['exclude.bufnames'] = { config.exclude.bufnames, 'table' },
     })
 
     return config

--- a/lua/focus/init.lua
+++ b/lua/focus/init.lua
@@ -46,6 +46,7 @@ Focus.config = {
             list = '+1', -- Set the comma-saperated list for the colorcolumn
         },
         signcolumn = true, -- Display signcolumn in the focussed window only
+        signcolumn_focused_value = 'auto', -- Set the value of signcolumn for the focused window only (yes, number, auto)
         winhighlight = false, -- Auto highlighting for focussed/unfocussed windows
     },
 }
@@ -197,6 +198,11 @@ H.setup_config = function(config)
         ['ui.cursorcolumn'] = { config.ui.cursorcolumn, 'boolean' },
         ['ui.colorcolumn'] = { config.ui.colorcolumn, 'table', true },
         ['ui.signcolumn'] = { config.ui.signcolumn, 'boolean' },
+        ['ui.signcolumn_focused_value'] = {
+            config.ui.signcolumn_focused_value,
+            'string',
+        },
+        ['ui.winhighlight'] = { config.ui.winhighlight, 'boolean' },
         ['ui.winhighlight'] = { config.ui.winhighlight, 'boolean' },
     })
 

--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -13,8 +13,8 @@ local M = {}
 
 -- if focus auto signcolumn is set to true then
 -- we assume it to be auto in case signcolumn = no
-local function get_sign_column()
-    local default_signcolumn = 'auto'
+local function get_sign_column(config)
+    local default_signcolumn = config.ui.signcolumn_focused_value or 'auto'
     if vim.opt.signcolumn:get() == 'no' then
         return default_signcolumn
     else
@@ -91,7 +91,7 @@ function M.setup(config)
                 if utils.is_disabled() then
                     return
                 end
-                vim.wo.signcolumn = get_sign_column()
+                vim.wo.signcolumn = get_sign_column(config)
             end,
             desc = 'Enable signcolumn',
         })

--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -98,6 +98,9 @@ function M.setup(config)
         vim.api.nvim_create_autocmd({ 'BufLeave', 'WinLeave' }, {
             group = augroup,
             callback = function(_)
+                if utils.is_disabled() then
+                    return
+                end
                 vim.wo.signcolumn = 'no'
             end,
             desc = 'Disable signcolumn',

--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -150,6 +150,9 @@ function M.setup(config)
         vim.api.nvim_create_autocmd({ 'BufLeave', 'WinLeave' }, {
             group = augroup,
             callback = function(_)
+                if utils.is_disabled() then
+                    return
+                end
                 vim.wo.number = false
             end,
             desc = 'Disable cursorline',

--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -292,12 +292,12 @@ function M.setup(config)
         })
     end
 
-    if #config.exclude.filetypes > 0 then
+    if #config.excluded.filetypes > 0 then
         vim.api.nvim_create_autocmd({ 'FileType' }, {
             group = augroup,
             callback = function(_)
                 if
-                    vim.tbl_contains(config.exclude.filetypes, vim.bo.filetype)
+                    vim.tbl_contains(config.excluded.filetypes, vim.bo.filetype)
                 then
                     vim.b.focus_disable = true
                 end
@@ -306,7 +306,7 @@ function M.setup(config)
         })
     end
 
-    if #config.exclude.buftypes > 0 then
+    if #config.excluded.buftypes > 0 then
         vim.api.nvim_create_autocmd(
             { 'BufEnter', 'WinEnter', 'BufRead', 'BufNewFile' },
             {
@@ -314,7 +314,7 @@ function M.setup(config)
                 callback = function(_)
                     if
                         vim.tbl_contains(
-                            config.exclude.buftypes,
+                            config.excluded.buftypes,
                             vim.bo.buftype
                         )
                     then

--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -325,21 +325,6 @@ function M.setup(config)
             }
         )
     end
-
-    if #config.exclude.bufnames > 0 then
-        vim.api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
-            group = augroup,
-            callback = function(_)
-                if
-                    vim.tbl_contains(config.exclude.bufnames, vim.fn.bufname())
-                then
-                    vim.b.focus_disable = true
-                end
-            end,
-            desc = 'Disable focus autoresize for BufName',
-        })
-    end
-
     return M
 end
 

--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -161,7 +161,7 @@ function M.setup(config)
                     vim.wo.number = false
                     vim.wo.relativenumber = true
                 end,
-                desc = 'Absolutnumber unfoccused enter',
+                desc = 'Absolutenumber unfoccused enter',
             })
             vim.api.nvim_create_autocmd({ 'BufLeave', 'WinLeave' }, {
                 group = augroup,
@@ -172,7 +172,7 @@ function M.setup(config)
                     vim.wo.number = true
                     vim.wo.relativenumber = false
                 end,
-                desc = 'Absolutnumber unfoccused leave',
+                desc = 'Absolutenumber unfoccused leave',
             })
         else
             vim.api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
@@ -291,6 +291,50 @@ function M.setup(config)
             desc = 'Color column leave',
         })
     end
+
+    if #config.exclude.filetypes > 0 then
+        vim.api.nvim_create_autocmd({ 'FileType' }, {
+            group = augroup,
+            callback = function(_)
+                if
+                    vim.tbl_contains(config.exclude.filetypes, vim.bo.filetype)
+                then
+                    vim.b.focus_disable = true
+                end
+            end,
+            desc = 'Disable focus autoresize for FileType',
+        })
+    end
+
+    if #config.exclude.buftypes > 0 then
+        vim.api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
+            group = augroup,
+            callback = function(_)
+                if
+                    vim.tbl_contains(config.exclude.buftypes, vim.bo.buftype)
+                then
+                    vim.b.focus_disable = true
+                end
+            end,
+            desc = 'Disable focus autoresize for BufType',
+        })
+    end
+
+    if #config.exclude.bufnames > 0 then
+        vim.api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
+            group = augroup,
+            callback = function(_)
+                if
+                    vim.tbl_contains(config.exclude.bufnames, vim.fn.bufname())
+                then
+                    vim.b.focus_disable = true
+                end
+            end,
+            desc = 'Disable focus autoresize for BufName',
+        })
+    end
+
+    return M
 end
 
 return M

--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -307,17 +307,23 @@ function M.setup(config)
     end
 
     if #config.exclude.buftypes > 0 then
-        vim.api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
-            group = augroup,
-            callback = function(_)
-                if
-                    vim.tbl_contains(config.exclude.buftypes, vim.bo.buftype)
-                then
-                    vim.b.focus_disable = true
-                end
-            end,
-            desc = 'Disable focus autoresize for BufType',
-        })
+        vim.api.nvim_create_autocmd(
+            { 'BufEnter', 'WinEnter', 'BufRead', 'BufNewFile' },
+            {
+                group = augroup,
+                callback = function(_)
+                    if
+                        vim.tbl_contains(
+                            config.exclude.buftypes,
+                            vim.bo.buftype
+                        )
+                    then
+                        vim.b.focus_disable = true
+                    end
+                end,
+                desc = 'Disable focus autoresize for BufType',
+            }
+        )
     end
 
     if #config.exclude.bufnames > 0 then


### PR DESCRIPTION
The first commit adds a new feature that allows users to change the value of the sign column in the focused window from auto to yes
The second commit fixes a bug that caused the sign column to update even when leave bufer but that buffer is disabled .  Please review and merge these changes.
The third and fourth commit bring exclude filetypes comback